### PR TITLE
メールアドレスバリデーションを実装

### DIFF
--- a/src/handlers/signup.ts
+++ b/src/handlers/signup.ts
@@ -27,6 +27,11 @@ signup.post("/signup", async (c) => {
     return c.json({ error: "Invalid input data" }, 400);
   }
 
+  // emailのバリデーション ドメインが@mamiya-its.co.jpであること
+  if (!email.endsWith("@mamiya-its.co.jp")) {
+    return c.json({ error: "Invalid email" }, 400);
+  }
+
   const db = drizzle(c.env.DB);
   const user = await db
     .insert(users)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - サインアップ時に「@mamiya-its.co.jp」ドメインのメールアドレスのみを許可するようにメール検証機能を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->